### PR TITLE
add pptx for AllowedFileExtensions variable.

### DIFF
--- a/conf/config-defaults.php
+++ b/conf/config-defaults.php
@@ -91,7 +91,7 @@ $Configuration['Garden']['VanillaUrl'] = 'https://open.vanillaforums.com';
 // File handling.
 $Configuration['Garden']['CanProcessImages'] = false;
 $Configuration['Garden']['Upload']['MaxFileSize'] = '50M';
-$Configuration['Garden']['Upload']['AllowedFileExtensions'] = ['txt', 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico', 'zip', 'gz', 'tar.gz', 'tgz', 'psd', 'ai', 'fla', 'pdf', 'doc', 'xls', 'ppt', 'docx', 'xlsx', 'log', 'rar', '7z'];
+$Configuration['Garden']['Upload']['AllowedFileExtensions'] = ['txt', 'jpg', 'jpeg', 'gif', 'png', 'bmp', 'tiff', 'ico', 'zip', 'gz', 'tar.gz', 'tgz', 'psd', 'ai', 'fla', 'pdf', 'doc', 'xls', 'ppt', 'docx', 'xlsx', 'pptx', 'log', 'rar', '7z'];
 $Configuration['Garden']['Profile']['MaxHeight'] = 1200;
 $Configuration['Garden']['Profile']['MaxWidth'] = 800;
 $Configuration['Garden']['Thumbnail']['Size'] = 120;


### PR DESCRIPTION
word(.doc) and excel(.xls) are includes .docx and .xlsx extension for AllowedFileExtensions.
but powerpoint(ppt) is not include .pptx extension in AllowedFileExtensions.
